### PR TITLE
Added support for optionally highlighting a widget for a tutorial step

### DIFF
--- a/Editor/Scripts/demo_tutorial.py
+++ b/Editor/Scripts/demo_tutorial.py
@@ -5,6 +5,8 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
+from PySide2.QtWidgets import QMenuBar
+
 from tutorial import Tutorial, TutorialStep
 
 
@@ -14,6 +16,7 @@ class DemoTutorial(Tutorial):
 
         self.title = "Demo Tutorial"
 
-        self.add_step(TutorialStep("First things first", "Do blah blah blah and click on foo"))
-        self.add_step(TutorialStep("Hello World", "Time to do foo bar baz"))
-        self.add_step(TutorialStep("Last things last", "Woo you did it!"))
+        self.add_step(TutorialStep("First things first", "Welcome! This first step shouldn't highlight any widget."))
+        self.add_step(TutorialStep("Select an Entity", "Next, select any Entity in the Entity Outliner", "EntityOutlinerWidgetUI"))
+        self.add_step(TutorialStep("Add a component", "Use the Add Component button to add a component to the Entity", "m_addComponentButton"))
+        self.add_step(TutorialStep("Cool menu bar", "This step is just to showcase highlighting an item without a direct name but by using a type pattern instead", {"type": QMenuBar}))

--- a/Editor/Scripts/interactivetutorials_dialog.py
+++ b/Editor/Scripts/interactivetutorials_dialog.py
@@ -8,17 +8,56 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 """InteractiveTutorials\\editor\\scripts\\InteractiveTutorials_dialog.py
 Generated from O3DE PythonToolGem Template"""
 
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QDialog, QDialogButtonBox, QLabel, QPushButton, QTextEdit, QVBoxLayout
+from PySide2 import QtCore
+from PySide2.QtCore import QMargins, Qt
+from PySide2.QtGui import QColor, QPainter, QPen
+from PySide2.QtWidgets import QDialog, QDialogButtonBox, QLabel, QPushButton, QTextEdit, QVBoxLayout, QWidget
+
+import editor_python_test_tools.pyside_utils as pyside_utils
 
 from demo_tutorial import DemoTutorial
 
+
+class HighlightWidget(QWidget):
+    def __init__(self, parent=None):
+        super(HighlightWidget, self).__init__(parent)
+
+        self.setWindowFlags(Qt.FramelessWindowHint | Qt.Tool | Qt.WindowTransparentForInput | Qt.WindowDoesNotAcceptFocus)
+        self.setAttribute(Qt.WA_TranslucentBackground);
+        self.setAttribute(Qt.WA_NoSystemBackground);
+        self.setAttribute(Qt.WA_TransparentForMouseEvents)
+
+        self.border_width = 5
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        pen = QPen(QColor(131, 238, 255))
+        pen.setWidth(self.border_width)
+        painter.setPen(pen)
+        painter.drawRect(event.rect())
+
+    def update_widget(self, item):
+        if item:
+            self.show()
+
+            # Position our highlight widget on top of the specified item, but with an offset
+            # so that the rectangle border that we draw doesn't overlap the actual item itself
+            item_size = item.size()
+            new_size = item_size.grownBy(QMargins(self.border_width / 2, self.border_width / 2, 0, 0))
+            self.resize(new_size)
+            self.window().move(item.mapToGlobal(QtCore.QPoint(-self.border_width / 2, -self.border_width / 2)))
+            self.raise_()
+        else:
+            self.hide()
 
 class InteractiveTutorialsDialog(QDialog):
     def __init__(self, parent=None):
         super(InteractiveTutorialsDialog, self).__init__(parent)
 
         self.main_layout = QVBoxLayout(self)
+
+        self.highlight_widget = HighlightWidget()
+        self.highlight_widget.hide()
 
         self.title_label = QLabel(self)
         self.main_layout.addWidget(self.title_label)
@@ -57,6 +96,17 @@ class InteractiveTutorialsDialog(QDialog):
 
         self.title_label.setText(self.current_step.get_title())
         self.content_area.setText(self.current_step.get_content())
+
+        # If a highlight pattern was set for this step, then find that widget/item
+        # and highlight it
+        highlight_pattern = self.current_step.get_highlight_pattern()
+        if highlight_pattern:
+            item = pyside_utils.find_child_by_pattern(None, highlight_pattern)
+            self.highlight_widget.update_widget(item)
+            if not item:
+                print(f"Couldn't find widget or item matching pattern: { highlight_pattern }")
+        else:
+            self.highlight_widget.update_widget(None)
 
     def on_next_button_clicked(self):
         if self.current_step and self.current_step.next_step:

--- a/Editor/Scripts/tutorial.py
+++ b/Editor/Scripts/tutorial.py
@@ -8,9 +8,16 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 # Class that describes a step in the tutorial
 class TutorialStep:
-    def __init__(self, title, content):
+    def __init__(self, title, content, highlight_pattern=None):
         self.title = title
         self.content = content
+
+        # The highlight pattern is a widget/item that will be highlighted
+        # for this particular step (can be None)
+        # This pattern will be passed to `editor_python_test_tools.pyside_utils`
+        # to find the widget/item. See its documentation for supported patterns
+        self.highlight_pattern = highlight_pattern
+
         self.prev_step = None
         self.next_step = None
 
@@ -19,6 +26,9 @@ class TutorialStep:
 
     def get_content(self):
         return self.content
+
+    def get_highlight_pattern(self):
+        return self.highlight_pattern
 
 # Top-level entry point for describing a tutorial which is made up of a series of steps
 class Tutorial:


### PR DESCRIPTION
Added support for highlighting a widget/item using a pattern for a given tutorial step.
- Utilizes the existing `pyside_utils` API for finding an object based on a number of pattern parameters
- Added highlight widget for showcasing specified widget/item
- Updated demo example tutorial to showcase several ways of specifying a pattern

![HighlightingWidgets](https://user-images.githubusercontent.com/7519264/160492167-c333548b-a0cf-40e4-b581-9f8ff6805c24.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>