### PR TITLE
Made highlighting widget always stay on top

### DIFF
--- a/Editor/Scripts/interactivetutorials_dialog.py
+++ b/Editor/Scripts/interactivetutorials_dialog.py
@@ -22,7 +22,7 @@ class HighlightWidget(QWidget):
     def __init__(self, parent=None):
         super(HighlightWidget, self).__init__(parent)
 
-        self.setWindowFlags(Qt.FramelessWindowHint | Qt.Tool | Qt.WindowTransparentForInput | Qt.WindowDoesNotAcceptFocus)
+        self.setWindowFlags(Qt.FramelessWindowHint | Qt.Tool | Qt.WindowTransparentForInput | Qt.WindowDoesNotAcceptFocus | Qt.WindowStaysOnTopHint)
         self.setAttribute(Qt.WA_TranslucentBackground);
         self.setAttribute(Qt.WA_NoSystemBackground);
         self.setAttribute(Qt.WA_TransparentForMouseEvents)


### PR DESCRIPTION
Make sure our highlighting widget always stays on top.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>