### PR TITLE
Added start/end optional hooks to the tutorials and steps

### DIFF
--- a/Editor/Scripts/demo_tutorial.py
+++ b/Editor/Scripts/demo_tutorial.py
@@ -10,6 +10,18 @@ from PySide2.QtWidgets import QMenuBar
 from tutorial import Tutorial, TutorialStep
 
 
+# Example of a custom step that overrides the start/end hooks
+class SelectEntityStep(TutorialStep):
+    def __init__(self):
+        super(SelectEntityStep, self).__init__("Select an Entity",
+            "Next, select any Entity in the Entity Outliner", "EntityOutlinerWidgetUI")
+
+    def on_step_start(self):
+        print("Starting the select Entity step")
+
+    def on_step_end(self):
+        print("Ended the select Entity step")
+
 class DemoTutorial(Tutorial):
     def __init__(self):
         super(DemoTutorial, self).__init__()
@@ -17,9 +29,12 @@ class DemoTutorial(Tutorial):
         self.title = "Demo Tutorial"
 
         self.add_step(TutorialStep("First things first", "Welcome! This first step shouldn't highlight any widget."))
-        self.add_step(TutorialStep("Select an Entity", "Next, select any Entity in the Entity Outliner", "EntityOutlinerWidgetUI"))
+        self.add_step(SelectEntityStep())
         self.add_step(TutorialStep("Add a component", "Use the Add Component button to add a component to the Entity", "m_addComponentButton"))
         self.add_step(TutorialStep("Cool menu bar", "This step is just to showcase highlighting an item without a direct name but by using a type pattern instead", {"type": QMenuBar}))
+
+    def on_tutorial_start(self):
+        print("Where we're going, we don't need roads")
 
 class IntroTutorial(Tutorial):
     def __init__(self):

--- a/Editor/Scripts/tutorial.py
+++ b/Editor/Scripts/tutorial.py
@@ -21,6 +21,18 @@ class TutorialStep:
         self.prev_step = None
         self.next_step = None
 
+    # Method that will be called when the step starts
+    # A step class can override this method if they need
+    # to setup any special handling/listeners
+    def on_step_start(self):
+        pass
+
+    # Method that will be called after a step has ended
+    # A step class can override this method if they need
+    # to perform any cleanup or other tasks
+    def on_step_end(self):
+        pass
+
     def get_title(self):
         return self.title
 
@@ -35,6 +47,18 @@ class Tutorial:
     def __init__(self):
         self.steps = []
         self.title = ""
+
+    # Method that will be called when the tutorial starts
+    # A tutorial class can override this method if they need
+    # to setup any special handling/listeners
+    def on_tutorial_start(self):
+        pass
+
+    # Method that will be called after a tutorial has ended
+    # A tutorial class can override this method if they need
+    # to perform any cleanup or other tasks
+    def on_tutorial_end(self):
+        pass
 
     def get_title(self):
         return self.title


### PR DESCRIPTION
Added feature to allow tutorials and steps to optionally have start/end methods that are invoked accordingly, for the user to inject any special handling/listeners as needed. Also did a slight refactor of the tutorial/step loading to cleanup and make it easier to add these optional hooks. Expanded the demo tutorial to make use of these new features.

![StartEndHooksDemo](https://user-images.githubusercontent.com/7519264/161105505-99b0032f-6c76-4b34-979e-7b0543e3ce2d.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>