### PR TITLE
Finding Qt objects by parent or parent/index

### DIFF
--- a/Editor/Scripts/create_wind_forces_tutorial.py
+++ b/Editor/Scripts/create_wind_forces_tutorial.py
@@ -25,7 +25,7 @@ class WindForcesTutorial(Tutorial):
                 <b>Wind Configuration</b> includes the <b>Global wind tag</b> and the <b>Local wind tag</b>. </p></html>""", "EntityOutlinerWidgetUI"))
         self.add_step(TutorialStep("Update the Shape", """<html><p style="font-size:13px">Set the PhysX Collider component's Shape
                 property to <i>Box</i>. </p></html>""", "AzAssetBrowserWindowClass"))
-        self.add_step(TutorialStep("Scale the Entity", """<html><p style="font-size:13px">Adjust the <b>Box Dimensions>
+        self.add_step(TutorialStep("Scale the Entity", """<html><p style="font-size:13px">Adjust the <b>Box Dimensions</b>
                 to your specifications. If you're creating a localized wind force, make the dimenesions large enough that they can 
                 contain the entity that receives the wind force.</p></html>""", "InspectorMainWindow"))
         self.add_step(TutorialStep("Position the Entity", """<html><p style="font-size:13px"> Use the <b>Move</b> tool 

--- a/Editor/Scripts/create_wind_forces_tutorial.py
+++ b/Editor/Scripts/create_wind_forces_tutorial.py
@@ -5,11 +5,6 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-import sys
-import azlmbr
-
-from PySide2.QtWidgets import QMenuBar
-
 from tutorial import Tutorial, TutorialStep
 
 class WindForcesTutorial(Tutorial):
@@ -40,15 +35,15 @@ class WindForcesTutorial(Tutorial):
                 Select the <b>Add</b> button located next to <b>Forces</b>. Then, in the <b>Direction</b> property
                 of your new force, set the <b>Y</b> component to <i>-1.0</i>, and the <b>Z</b> component to <i>0.0</i>, to create
                 a direction for the wind. The PhysX collider box displays cones indicating the direction of the wind force. <br>
-                Set the <b>Magnitude</b> to <i>10.0</i>. </p></html>""", "AzAssetBrowserWindowClass"))
+                Set the <b>Magnitude</b> to <i>10.0</i>. </p></html>""", "InspectorMainWindow"))
         self.add_step(TutorialStep("Add a Cloth Prefab", """<html><p style="font-size:13px">We'll test the wind provider by adding
                 a NVIDIA Cloth Mesh. In <b>Asset Browser</b>, navigate to <i>Gems\NvCloth\Assets\prefabs\Cloth</i>, then locate
-                <i>cloth_locked_edge.prefab</i>, and drag that asset into the viewport. </p></html>""", "EntityOutlinerWidgetUI"))
+                <i>cloth_locked_edge.prefab</i>, and drag that asset into the viewport. </p></html>""", "AzAssetBrowserWindowClass"))
         self.add_step(TutorialStep("Position the Prefab", """<html><p style="font-size:13px">Use the Move tool to place the cloth prefab. 
                 Once the prefab's in position, you can hide the wind provider entity. In <b>Entity Outliner</b>, in the column to the 
                 right of the wind provider entity, toggle the <b>Show/Hide Entity</b> setting. <br><br>Note: if you're using the 
                 <b>Local wind tag</b>, you must place the cloth asset inside the PhysX Collider volume of the wind provider entity. 
-                </p></html>""", "InspectorMainWindow"))
+                </p></html>""", "EntityOutlinerWidgetUI"))
         self.add_step(TutorialStep("Edit the Prefab", """<html><p style="font-size:13px">The cloth prefab has a local wind property 
                 enabled which generates a local wind force that overrides our wind provider entity. We will deactiate the local
                 wind force of the prefab so that we can view the results of the wind provider we created. <br><br>

--- a/Editor/Scripts/create_wind_forces_tutorial.py
+++ b/Editor/Scripts/create_wind_forces_tutorial.py
@@ -1,0 +1,69 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+import sys
+import azlmbr
+
+from PySide2.QtWidgets import QMenuBar
+
+from tutorial import Tutorial, TutorialStep
+
+class WindForcesTutorial(Tutorial):
+    def __init__(self):
+        super(WindForcesTutorial, self).__init__()
+
+        self.title = "Create Wind Forces"
+
+        self.add_step(TutorialStep("Create Wind Forces", """<html><p style="font-size:13px">Greetings!<br><br>We can use a <b>PhysX Force Region</b> component to
+                create both global and local wind forces. Wind forces affect entities with components that are affected by wind,
+                such as cloth. Wind forces don't affect <b>PhysX Rigid Body</b> components.
+                For this tutorial, make sure that you have the <b>Nvidia Cloth Gem</b> enabled in your project.
+                <br><br>Click next to continue.</p></html>"""))
+        self.add_step(TutorialStep("Create a wind provider entity", """<html><p style="font-size:13px"><li>First, create an entity 
+                for the wind provider. <li>Next, add a <b>Tag</b> component for the entity. The Tag will specify whether the 
+                wind is a global or a local force. Edit the tag value to specify the wind type by choosing <b>PhysX Configuration</b>
+                from the <b>Tools</b> menu and toggling the <b>Wind Configuration</b>. <br><br>
+                <b>Wind Configuration</b> includes the <b>Global wind tag</b> and the <b>Local wind tag</b>. </p></html>""", "EntityOutlinerWidgetUI"))
+        self.add_step(TutorialStep("Update the Shape", """<html><p style="font-size:13px">Set the PhysX Collider component's Shape
+                property to <i>Box</i>. </p></html>""", "AzAssetBrowserWindowClass"))
+        self.add_step(TutorialStep("Scale the Entity", """<html><p style="font-size:13px">Adjust the <b>Box Dimensions>
+                to your specifications. If you're creating a localized wind force, make the dimenesions large enough that they can 
+                contain the entity that receives the wind force.</p></html>""", "InspectorMainWindow"))
+        self.add_step(TutorialStep("Position the Entity", """<html><p style="font-size:13px"> Use the <b>Move</b> tool 
+                to position the entity in the level. For instance, you might consider positioning the entity so that 
+                the bottom of the box is level with the ground. </p></html>""", "InspectorMainWindow"))
+        self.add_step(TutorialStep("Add a PhysX Region component to the entity", """<html><p style="font-size:13px"> 
+                Select the <b>Add</b> button located next to <b>Forces</b>. Then, in the <b>Direction</b> property
+                of your new force, set the <b>Y</b> component to <i>-1.0</i>, and the <b>Z</b> component to <i>0.0</i>, to create
+                a direction for the wind. The PhysX collider box displays cones indicating the direction of the wind force. <br>
+                Set the <b>Magnitude</b> to <i>10.0</i>. </p></html>""", "AzAssetBrowserWindowClass"))
+        self.add_step(TutorialStep("Add a Cloth Prefab", """<html><p style="font-size:13px">We'll test the wind provider by adding
+                a NVIDIA Cloth Mesh. In <b>Asset Browser</b>, navigate to <i>Gems\NvCloth\Assets\prefabs\Cloth</i>, then locate
+                <i>cloth_locked_edge.prefab</i>, and drag that asset into the viewport. </p></html>""", "EntityOutlinerWidgetUI"))
+        self.add_step(TutorialStep("Position the Prefab", """<html><p style="font-size:13px">Use the Move tool to place the cloth prefab. 
+                Once the prefab's in position, you can hide the wind provider entity. In <b>Entity Outliner</b>, in the column to the 
+                right of the wind provider entity, toggle the <b>Show/Hide Entity</b> setting. <br><br>Note: if you're using the 
+                <b>Local wind tag</b>, you must place the cloth asset inside the PhysX Collider volume of the wind provider entity. 
+                </p></html>""", "InspectorMainWindow"))
+        self.add_step(TutorialStep("Edit the Prefab", """<html><p style="font-size:13px">The cloth prefab has a local wind property 
+                enabled which generates a local wind force that overrides our wind provider entity. We will deactiate the local
+                wind force of the prefab so that we can view the results of the wind provider we created. <br><br>
+                In Entity Outliner, double-click the <b>cloth_locked_edge</b> prefab to edit it in Focus Mode, and select the <b>cloth_locked_edge</b>
+                entity. Then, in the Cloth component of the Entity Inspector, expand the <b>Wind</b> propoerty group and deselect
+                <b>Enable local wind velocity</b>. </p></html>""", "EntityOutlinerWidgetUI"))
+        self.add_step(TutorialStep("Run the simulation", """<html><p style="font-size:13px">We can now run the 
+                simualtion and view the results. With the <b>cloth_locked_edge</b> prefab open for editing in Focus mode, select the 
+                <b> Simulate in editor</b> option located at the top of the Cloth component. As the simulation begins, the cloth object might flip and 
+                stretch wildly, but it will quickly settle into a breezy wind simulation. The simulation plays while in editor mode, so you can 
+                adjust various properties within the Cloth component and view the results in real time. <br>Consider adjusting the: <li>
+                Air drag coefficient <li>Air lift coefficient<li>Air density<br></p></html>""","InspectorMainWindow"))
+    def on_tutorial_start(self):
+        print("Starting Wind Forces tutorial.")
+
+    def on_tutorial_end(self):
+        print("Wind Forces tutorial complete!")
+

--- a/Editor/Scripts/customize_mesh_asset_processing.py
+++ b/Editor/Scripts/customize_mesh_asset_processing.py
@@ -1,0 +1,62 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+import sys
+import azlmbr
+
+from PySide2.QtWidgets import QMenuBar
+
+from tutorial import Tutorial, TutorialStep
+
+class CustomizeMeshAssetProcessingTutorial(Tutorial):
+    def __init__(self):
+        super(CustomizeMeshAssetProcessingTutorial, self).__init__()
+
+        self.title = "Customize Mesh Asset Processing"
+
+        self.add_step(TutorialStep("Customize Mesh Asset Processing", 
+                """<html><p style="font-size:13px">Greetings!<br><br><i> Meshes </i> refer to the external appearances
+                of objects.<br>In this tutorial, we'll edit the mesh of a sphere by enlarging it. We'll also introduce
+                some other ways you can edit the mesh. <br><br>Click next to continue.</p></html>"""))
+        self.add_step(TutorialStep("Preparing the scene", """<html><p style="font-size:13px">The <b>Asset Processor </b> runs 
+                in the background automatically detecting source assets and scheduling process jobs for them.
+                <br><br>In <b>Asset Processor</b>, search for the <b>sphere.fbx</b> source asset and 
+                right click to expand it. Select 'Edit Settings'.
+                </p></html>""", "AzAssetBrowserWindowClass"))
+        self.add_step(TutorialStep("Edit the Scene Settings", """<html><p style="font-size:13px">By default, 
+                all the meshes in a source asset are processed as a single group, each of which produces a set of product assets. Let's create additional mesh groups for our sphere source asset by
+                choosing <b>Add another mesh.</b><br><br>
+                The Name mesh property contains the name of the source asset.
+                The Select meshes property reads All meshes selected. 
+                You can choose the file select button to select which meshes to include in the mesh group.
+                For this tutorial, you can use the default mesh group with all meshes selected.
+                </p></html>""", "AzAssetBrowserWindowClass"))
+        self.add_step(TutorialStep("Change the Coordinate System", """<html><p style="font-size:13px">Let’s add a modifier to customize 
+                how the asset is processed. Choose the <b>Add Modifier</b> button to view the mesh modifier list 
+                and select <b>Coordinate system change</b>. <br><br>
+                The Coordinate system change mesh modifier is used to scale or transform the asset for scenarios 
+                where the asset might be too small, too large, or incorrectly oriented in O3DE. 
+                By default, the modifier provides a single option to rotate the mesh 180 degrees. 
+                Activate the <b>Use advanced settings</b> toggle to expose the advanced modifier settings.<br><br>
+                Let’s customize the scale of the asset. Set the <b>Scale</b> property to <i>5.0</i> to scale the asset to five times its size.
+                </p></html>""", "AzAssetBrowserWindowClass"))
+        self.add_step(TutorialStep("View Changes", """<html><p style="font-size:13px">To use the prefab in our 
+                level we need to create an instance, or <i>instantiate</i> the prefab in the level.<br><br>Drag the 
+                <strong><code style="font-size:14px;color:#E44C9A">20-sided-dice.prefab</code></strong> into the 
+                viewport to instatiate it in the level.</p></html>""", "EntityOutlinerWidgetUI"))
+        self.add_step(TutorialStep("Position the prefab", """<html><p style="font-size:13px"> 
+                Choose the <b>Update</b> button at the bottom-right of Scene Settings. 
+                This creates or updates the .assetinfo sidecar file and triggers Asset Processor to reprocess the asset.
+                Drag the .azmodel product asset from Asset Browser into the viewport.
+                </p></html>""", "renderOverlay"))
+
+    def on_tutorial_start(self):
+        print("Starting Mesh Asset Process tutorial.")
+
+    def on_tutorial_end(self):
+        print("Mesh Asset Process tutorial complete!")
+

--- a/Editor/Scripts/customize_mesh_asset_processing.py
+++ b/Editor/Scripts/customize_mesh_asset_processing.py
@@ -5,11 +5,6 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-import sys
-import azlmbr
-
-from PySide2.QtWidgets import QMenuBar
-
 from tutorial import Tutorial, TutorialStep
 
 class CustomizeMeshAssetProcessingTutorial(Tutorial):
@@ -24,7 +19,7 @@ class CustomizeMeshAssetProcessingTutorial(Tutorial):
                 some other ways you can edit the mesh. <br><br>Click next to continue.</p></html>"""))
         self.add_step(TutorialStep("Preparing the scene", """<html><p style="font-size:13px">The <b>Asset Processor </b> runs 
                 in the background automatically detecting source assets and scheduling process jobs for them.
-                <br><br>In <b>Asset Processor</b>, search for the <b>sphere.fbx</b> source asset and 
+                <br><br>In <b>Asset Browser</b>, search for the <b>sphere.fbx</b> source asset and 
                 right click to expand it. Select 'Edit Settings'.
                 </p></html>""", "AzAssetBrowserWindowClass"))
         self.add_step(TutorialStep("Edit the Scene Settings", """<html><p style="font-size:13px">By default, 
@@ -47,7 +42,7 @@ class CustomizeMeshAssetProcessingTutorial(Tutorial):
         self.add_step(TutorialStep("View Changes", """<html><p style="font-size:13px">To use the prefab in our 
                 level we need to create an instance, or <i>instantiate</i> the prefab in the level.<br><br>Drag the 
                 <strong><code style="font-size:14px;color:#E44C9A">20-sided-dice.prefab</code></strong> into the 
-                viewport to instatiate it in the level.</p></html>""", "EntityOutlinerWidgetUI"))
+                viewport to instatiate it in the level.</p></html>""", "AzAssetBrowserWindowClass"))
         self.add_step(TutorialStep("Position the prefab", """<html><p style="font-size:13px"> 
                 Choose the <b>Update</b> button at the bottom-right of Scene Settings. 
                 This creates or updates the .assetinfo sidecar file and triggers Asset Processor to reprocess the asset.

--- a/Editor/Scripts/decompose_input_meshes.py
+++ b/Editor/Scripts/decompose_input_meshes.py
@@ -1,0 +1,47 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+import sys
+import azlmbr
+
+from PySide2.QtWidgets import QMenuBar
+
+from tutorial import Tutorial, TutorialStep
+
+class DecomposeInputMeshes(Tutorial):
+    def __init__(self):
+        super(DecomposeInputMeshes, self).__init__()
+
+        self.title = "Decompose Input Meshes"
+
+        self.add_step(TutorialStep("Decompose Input Meshes", 
+                """<html><p style="font-size:13px">Greetings!<br><br>Assets composed of multiple and/or complex meshes, 
+                such as some kinematic or dynamic entities, might require similarly complex PhysX collider assets. In these cases,
+                you can decompose the input mesh into convex parts. You can automatically generate primitive or convex colliders,
+                fit them to each part, and process them as collider <i>.pxmesh</i> product assets. <br><br>
+                Mesh decomposition is part of the process of 
+                generating and fitting primitive or convex collider assets, and it doesn’t alter the input mesh. 
+                .<br><br>Click next to continue.</p></html>"""))
+        self.add_step(TutorialStep("Select the Asset", """<html><p style="font-size:13px">Locate your source asset in the 
+                <b>Asset Browser</b>. You can use your own or use one of the provided <i>.fbx</i> files, such as <i>sphere.fbx</i>. 
+                Right click the <i>.fbx</i> source asset and select 'Edit Settings.' 
+                </p></html>""", "AzAssetBrowserWindowClass"))
+        self.add_step(TutorialStep("Decompose Meshes", """<html><p style="font-size:13px">In Scene Settings, underneath 
+                <b>PhysX Mesh Group</b>, choose to <b>Export As</b> either <i>Primitive</i> or <i>Convex</i>. Then enable
+                <b>Decompose Meshes</b>. <br><br>
+                <li>For primitive colliders, the input mesh is decomposed into primitive parts. The best fitting primitive shapes 
+                are automatically selected and transformed to encompass each part and the primitives are processed as a 
+                product asset. <li>For convex colliders, the input mesh is decomposed into convex parts.
+                A convex hull is generated for each part and the convex hulls are processed as a collider product asset. 
+                In general, collider assets generated with decomposed meshes provide a more accurate representation of 
+                the render mesh than a single primitive or convex collider can.  </p></html>""", "EntityOutlinerWidgetUI"))
+  
+    def on_tutorial_start(self):
+        print("Starting tutorial to decompose input meshes.")
+
+    def on_tutorial_end(self):
+        print("'Decompose input meshes' tutorial complete!")

--- a/Editor/Scripts/decompose_input_meshes.py
+++ b/Editor/Scripts/decompose_input_meshes.py
@@ -5,11 +5,6 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-import sys
-import azlmbr
-
-from PySide2.QtWidgets import QMenuBar
-
 from tutorial import Tutorial, TutorialStep
 
 class DecomposeInputMeshes(Tutorial):

--- a/Editor/Scripts/finding_ui_objects.py
+++ b/Editor/Scripts/finding_ui_objects.py
@@ -1,0 +1,51 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+import sys
+import azlmbr
+
+from PySide2 import QtWidgets
+import editor_python_test_tools.pyside_utils as pyside_utils
+
+from tutorial import Tutorial, TutorialStep
+
+class FindingUIObjectsTutorial(Tutorial):
+    def __init__(self):
+        super(FindingUIObjectsTutorial, self).__init__()
+
+        self.title = "Highlighting UI Objects"
+
+        self.add_step(TutorialStep("Highlighting UI Objects", 
+                """<html><p style="font-size:13px">Greetings!<br><br>This tutorial demonstrates methods to find UI 
+                objects to highlight in tutorial steps. You can use the <b>Object Tree</b> tool to find named UI 
+                objects or a named parent of a UI object. Then, use one of methods in this tutorial to specify the 
+                widget to highlight in a <strong><code style="font-size:14px;color:#E44C9A">TutorialStep</code></strong>
+                .<br><br>The available methods are:<ul><li><b>Highlight by name</b> - Specify the name of the 
+                UI object to highlight.</li><li><b>Highlight by parent</b> - Specify a named parent and a pattern for 
+                the UI object. The UI object is the first child of the parent that matches the specified pattern.</li>
+                <li><b>Highlight from hierarchy with index</b> - Specify an index to select a specific child UI object 
+                when the parent has multiple children that have the same pattern.</li></ul></p></html>"""))
+        self.add_step(TutorialStep("Highlight by name", """<html><p style="font-size:13px">This step highlights the 
+                <b>Entity Outliner</b>, finding it by its name, <strong><code style="font-size:14px;color:#E44C9A">
+                "EntityOutlinerWidgetUI"</code></strong>.</p></html>""", "EntityOutlinerWidgetUI"))
+        self.add_step(TutorialStep("Highlight from parent", """<html><p style="font-size:13px">This step highlights 
+                the <b>Console Variables</b> tool button in the lower-left corner of the Editor. The Console Variables 
+                tool button has a name, but is found through its parent in this example. It is the first QToolButton 
+                child of a QWidget named <strong><code style="font-size:14px;color:#E44C9A">container2</code></strong>.
+                </p></html>""", QtWidgets.QToolButton, "container2"))
+        self.add_step(TutorialStep("Highlight from hierarchy with index", """<html><p style="font-size:13px">This step 
+                highlights the <b>Play</b> tool button in the upper-right corner of the Editor. The Play tool button is 
+                unnamed, and it is the third QToolButton child of a QToolBar named 
+                <strong><code style="font-size:14px;color:#E44C9A">PlayConsole</code></strong>. Supplying 
+                <strong><code style="font-size:14px;color:#E44C9A">2</code></strong> for the index value selects the 
+                third child QToolButton.</p></html>""", QtWidgets.QToolButton, "PlayConsole", 2))
+
+    def on_tutorial_start(self):
+        print("Starting Widget By Hierarchy tutorial.")
+
+    def on_tutorial_end(self):
+        print("Widget By Hierarchy tutorial complete!")

--- a/Editor/Scripts/interactivetutorials_dialog.py
+++ b/Editor/Scripts/interactivetutorials_dialog.py
@@ -28,9 +28,6 @@ from decompose_input_meshes import DecomposeInputMeshes
 from customize_mesh_asset_processing import CustomizeMeshAssetProcessingTutorial
 
 from tutorial import Tutorial
-#this is the class that knows what step you're on - reads the tutorial and controls what step is being shown
-#whenever update_step_view is called - steps.index self.current_step tells you the index 
-#counter 
 
 class HighlightWidget(QWidget):
     def __init__(self, parent=None):
@@ -168,11 +165,7 @@ class InteractiveTutorialsDialog(QDialog):
 
         tutorial_factory = self.tutorials[index]["tutorial"]
         self.current_tutorial = tutorial_factory()
-        #tutorial factory creates a new instance of the tutorial
-        #self.current_tutorial : rigid body / wind forces
-        #num_steps = len(self.currenttutorial.get_steps)
-        #^ store in self.current_turoail num steps
-        #whenever updatestepview gets called use  index and string to set the text on new label
+        
         self.current_tutorial_num_steps = len(self.current_tutorial.get_steps())
 
         # Invoke the tutorial start method
@@ -181,10 +174,8 @@ class InteractiveTutorialsDialog(QDialog):
         # Update the title based on the loaded tutorial
         self.setWindowTitle("InteractiveTutorials - " + self.current_tutorial.get_title())
 
-        #set counter
-        self.current_step_index = 0 
-        #wherever load next step and load previous step + 11 -1
         # Reset initial state and load first step
+        self.current_step_index = 0 
         self.current_step = None
         first_step = self.current_tutorial.get_first_step()
         self.load_step(first_step)
@@ -217,9 +208,8 @@ class InteractiveTutorialsDialog(QDialog):
 
         self.title_label.setText(self.current_step.get_title())
         self.content_area.setText(self.current_step.get_content())
-        self.step_label.setText("Step " + str(self.current_step_index) + " of " + str(self.current_tutorial_num_steps))
-        #whenever updatestepview gets called use  index and string to set the text on new label
-
+        self.step_label.setText(f"Step {self.current_step_index} of {self.current_tutorial_num_steps}")
+        
         # If there are no steps remaining in the tutorial, then
         # update the Next button text to "End"
         next_button_text = "Next"

--- a/Editor/Scripts/interactivetutorials_dialog.py
+++ b/Editor/Scripts/interactivetutorials_dialog.py
@@ -209,7 +209,6 @@ class InteractiveTutorialsDialog(QDialog):
         self.title_label.setText(self.current_step.get_title())
         self.content_area.setText(self.current_step.get_content())
         self.step_label.setText(f"Step {self.current_step_index} of {self.current_tutorial_num_steps}")
-        
         # If there are no steps remaining in the tutorial, then
         # update the Next button text to "End"
         next_button_text = "Next"
@@ -253,8 +252,8 @@ class InteractiveTutorialsDialog(QDialog):
 
     def load_previous_step(self):
         if self.current_step:
-            prev_step = self.current_step.prev_step
             self.current_step_index -= 1
+            prev_step = self.current_step.prev_step
             if prev_step:
                 self.current_step_index -= 1
                 self.load_step(prev_step)

--- a/Editor/Scripts/process_physx_collider_assets.py
+++ b/Editor/Scripts/process_physx_collider_assets.py
@@ -5,11 +5,6 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-import sys
-import azlmbr
-
-from PySide2.QtWidgets import QMenuBar
-
 from tutorial import Tutorial, TutorialStep
 
 class ColliderAssetsTutorial(Tutorial):
@@ -52,7 +47,7 @@ class ColliderAssetsTutorial(Tutorial):
                 in the viewport. Then, in <b>Entity Inspector</b>, select <b>Add Component</b> and then <b>PhysX Collider</b>.
                 The component we've just added automatically detects the <i>.pxmesh</i> asset. <br><br>
                 The <Shape> is set to <i>PhysicsAsset</i> and the <PhysX Mesh> references the <i>.pxmesh</i> product asset. <br><br><br>
-                </html>""", "AzAssetBrowserWindowClass"))
+                </html>""", "InspectorMainWindow"))
         self.add_step(TutorialStep("Optimize your Entity", """<html><p style="font-size:13px">Our entity is currently static, because 
                 we only have a PhysX Collider component. A static entity is solid (it can be collided with) but does not move
                 in response to collisions. <li>If you want a static entity, you can enable the <b>Static</b> property within the <b>Transform</b>

--- a/Editor/Scripts/process_physx_collider_assets.py
+++ b/Editor/Scripts/process_physx_collider_assets.py
@@ -1,0 +1,70 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+import sys
+import azlmbr
+
+from PySide2.QtWidgets import QMenuBar
+
+from tutorial import Tutorial, TutorialStep
+
+class ColliderAssetsTutorial(Tutorial):
+    def __init__(self):
+        super(ColliderAssetsTutorial, self).__init__()
+
+        self.title = "PhysX Collider Assets"
+
+        self.add_step(TutorialStep("Process PhysX Collider Assets", 
+                """<html><p style="font-size:13px">Greetings!<br><br><i>Collider assets</i> are assets
+                generated based on input meshes. There are various types of colliders, such as triangle, primitive, and convex. 
+                Colliders are categorized based on the shapes they are comprised of: triangle, sphere,
+                box, capsule, and/or convex. <br><br>In this tutorial, we'll edit an 
+                existing source asset to create a Physx collider asset. <br><br>Click next to continue.</p></html>"""))
+        self.add_step(TutorialStep("Select the Asset", """<html><p style="font-size:13px">Locate your source asset in the 
+                <b>Asset Browser</b>. You can use your own or use one of the provided <i>.fbx</i> files, such as <i>sphere.fbx</i>. 
+                Right click the <i>.fbx</i> source asset and select 'Edit Settings.' 
+                </p></html>""", "AzAssetBrowserWindowClass"))
+        self.add_step(TutorialStep("Add a PhysX Mesh", """<html><p style="font-size:13px"> Select the 
+                PhysX tab and select <b>Add another physxmesh</b> to create a PhysX mesh group. <br><br>
+                Each PhysX group produces as <i>.pxmesh</i> product asset.
+                </p></html>""", 
+                "AzAssetBrowserWindowClass"))
+        self.add_step(TutorialStep("Add a PhysX Mesh", """<html><p style="font-size:13px"> To select which 
+                meshes to include in the PhysX mesh group, use the file select button. <br><br> If you select multiple meshes, 
+                you might want to also enable the <b>Merge Meshes</b> and <b>Weld Vertices</b>
+                features to optimize the asset's appearance. 
+                </p></html>""", "AzAssetBrowserWindowClass"))
+        self.add_step(TutorialStep("Customize the PhysX Mesh Collider Type", """<html><p style="font-size:13px"> Customize the 
+                PhysX mesh collider type by setting the <b>Export As</b> property to the type you choose. You might prefer to 
+                selecct the 'Convex' type so that you can create any type of entity (static, kinematic, dynamic), but 
+                Triangle and Primitive types each also have their respective advantages and limitations. <br><br>You can visit the 
+                Docs online if you want to learn more.<br><br> Then select <b>Update</b> (in the bottom right corner) 
+                to update the <i>.assetinfo</i> file and trigger the Asset Processor. </p></html>""", "AzAssetBrowserWindowClass"))
+        self.add_step(TutorialStep("View the Entity", """<html><p style="font-size:13px"> .</li><li>Drag the <i>.azmodel</i> 
+                product asset into the viewport from the Asset Browser.<br><br> As you do this, O3DE automatically creates
+                an entity with a <b>Mesh</b> component referencing the mesh product asset. </li></p>
+                </p></html>""", "renderOverlay"))
+        self.add_step(TutorialStep("View the Entity with the Collider component", """<html><p style="font-size:13px" Select the entity 
+                in the viewport. Then, in <b>Entity Inspector</b>, select <b>Add Component</b> and then <b>PhysX Collider</b>.
+                The component we've just added automatically detects the <i>.pxmesh</i> asset. <br><br>
+                The <Shape> is set to <i>PhysicsAsset</i> and the <PhysX Mesh> references the <i>.pxmesh</i> product asset. <br><br><br>
+                </html>""", "AzAssetBrowserWindowClass"))
+        self.add_step(TutorialStep("Optimize your Entity", """<html><p style="font-size:13px">Our entity is currently static, because 
+                we only have a PhysX Collider component. A static entity is solid (it can be collided with) but does not move
+                in response to collisions. <li>If you want a static entity, you can enable the <b>Static</b> property within the <b>Transform</b>
+                component to maximize your entity's runtime performance. <li>If you want a dynamic entity, add a <b>PhysX Rigid Body</b>
+                component. (Make sure that the <b>Static</b> property in the <b>Transform</b> component is disabled.)
+                Select the entity in the viewport. Then, in <b> Entity Inspector</b>, select <b>Add Compoonent</b> and then 
+                <b>PhysX Rigid Body</b> to enable the effect of gravity on your entity. You can observe the changes by selecting the 
+                simulation button. <li>If you want a kinematic entity, add a <b>PhysX Rigid Body Component</b>. Then, within the component,
+                enable the <b>Kinematic</b> property. (Make sure that the <b>Static</b> property in the <b>Transform</b> component is disabled.) </p></html>""", "InspectorMainWindow"))
+        
+    def on_tutorial_start(self):
+        print("Starting PhysX Collider Assets tutorial.")
+
+    def on_tutorial_end(self):
+        print("PhysX Collider Assets tutorial complete!")

--- a/Editor/Scripts/rigid_body_tutorial.py
+++ b/Editor/Scripts/rigid_body_tutorial.py
@@ -31,44 +31,43 @@ class RigidBodyTutorial(Tutorial):
                 functionality. The <b>Sun</b> entity, for example, has a <b>Directional Light</b> component the 
                 simulates a very bright distant light with parallel rays. It also has a <b>Transform</b> component that 
                 places it in the level in realtion to it's parent, the <b>Atom Default Environment</b> entity.
-                <br><br><br>Step 1 of 20</p></html>""", "EntityOutlinerWidgetUI"))
+                </p></html>""", "EntityOutlinerWidgetUI"))
         self.add_step(TutorialStep("Delete the Shader Ball entity", """<html><p style="font-size:13px">Let's tidy up a 
                 bit.<br><br>In <b>Entity Outliner</b>, click the <b>Shader Ball</b> entity to select it and press 
-                <b>DEL</b> to remove it from the level.<br><br><br>Step 2 of 20</p></html>""", 
+                <b>DEL</b> to remove it from the level.</p></html>""", 
                 "EntityOutlinerWidgetUI"))
         self.add_step(TutorialStep("Find a prefab in Asset Browser", """<html><p style="font-size:13px">A <i>prefab</i> 
                 is a reusable asset that has been saved to disk and that can be added to a level as an instance or 
                 spawned at runtime. Let's find a prefab to use the basis of the rigid body.<br><br>In 
                 <b>Asset Browser</b>, use the <b>Search...</b> filter to find the 
                 <strong><code style="font-size:14px;color:#E44C9A">20-sided-dice.prefab</code></strong>.
-                <br><br><br>Step 3 of 20</p></html>""", "AzAssetBrowserWindowClass"))
+                </p></html>""", "AzAssetBrowserWindowClass"))
         self.add_step(TutorialStep("Instantiate a prefab", """<html><p style="font-size:13px">To use the prefab in our 
                 level we need to create an instance, or <i>instantiate</i> the prefab in the level.<br><br>Drag the 
                 <strong><code style="font-size:14px;color:#E44C9A">20-sided-dice.prefab</code></strong> into the 
-                viewport to instatiate it in the level.<br><br><br>Step 4 of 20</p></html>""", "renderOverlay"))
+                viewport to instatiate it in the level.</p></html>""", "renderOverlay"))
         self.add_step(TutorialStep("Position the prefab", """<html><p style="font-size:13px"> Use the <b>Move</b> tool 
                 to position the dice prefab instance in the camera's view.<ul><li>In the viewport, ensure the prefab 
                 instance is selected by clicking it.</li><li>Use the translate handles to drag the prefab instance so 
                 that it is in the yellow wireframe that represents the camera's view frustum.</li><li>Drag the prefab 
                 instance up so that it is a few units above the ground plane.</li></p>
-                <p><br>Step 5 of 20</p></html>""", "renderOverlay"))
+                </p></html>""", "renderOverlay"))
         self.add_step(TutorialStep("Open the prefab instance in Focus Mode", """<html><p style="font-size:13px">We'll 
                 need to add a couple components to the prefab. The prefab in the level is an instance so it has to be 
                 opened for editing in <b>Focus Mode</b><br><br>In <b>Entity Outliner</b> double-click the dice prefab 
                 instance to open it for editing.<br><br>Note that the prefab instance is highlighted in a light blue 
                 frame and that the viewport also has a light blue frame titled <b>Focus Mode</b>. In Focus Mode, any 
                 modifications we make happen in the context of the prefab instance that is open for editing.<br><br><br>
-                Step 6 of 20</p></html>""", "EntityOutlinerWidgetUI"))
+                </p></html>""", "EntityOutlinerWidgetUI"))
         self.add_step(TutorialStep("Edit the dice entity", """<html><p style="font-size:13px">With the dice prefab 
                 instance open for editing, we can see it contains an enity (denoted by a white box icon). We'll add some
                  PhysX components to this entity.<br><br>In <b>Enity Outliner</b> click the <b>20-sided-dice</b> entity 
-                to select it.<br><br><br>Step 7 of 20</p></html>""", "EntityOutlinerWidgetUI"))
+                to select it.</p></html>""", "EntityOutlinerWidgetUI"))
         self.add_step(TutorialStep("Inspect the dice entity", """<html><p style="font-size:13px"><b>Entity 
                 Inspector</b> displays the dice entity's three components.<ul><li><b>Transform</b> - Places and orients 
                 the entity in the local space of the prefab instance.</li><li><b>Mesh</b> - Supplies a render mesh for 
                 the entity.</li><li><b>Material</b> - Applies shaders and textures to the render mesh.</il></ul>In the 
-                next steps, we'll add and configure components in Entity Inspector.<br><br><br>Step 8 of 
-                20</p></html>""", "InspectorMainWindow"))
+                next steps, we'll add and configure components in Entity Inspector.</p></html>""", "InspectorMainWindow"))
         self.add_step(TutorialStep("Add a PhysX Collider", """<html><p style="font-size:13px">A collider is a simplified
                  mesh that defines a solid surface that can register collisions and overlaps with other colliders. To 
                 add a collider to the entity, we'll add a <b>PhysX Collider</b> component.<br><br>In 
@@ -81,69 +80,66 @@ class RigidBodyTutorial(Tutorial):
                 collider component, notice that the <b>Shape</b> property is set to 
                 <strong><code style="font-size:14px;color:#E44C9A">PhysicsAsset</code></strong> and that the 
                 <b>PhysX Mesh</b> property is set to <strong><code style="font-size:14px;color:#E44C9A"> 
-                20-sided-dice</code></strong>, the generated convex mesh.<br><br><br>Step 9 of 20</p></html>""", 
+                20-sided-dice</code></strong>, the generated convex mesh.</p></html>""", 
                 "m_addComponentButton"))
         self.add_step(TutorialStep("Add a PhysX Rigid Body", """<html><p style="font-size:13px">A rigid body is a 
                 dynamic hard surface that responds to collisions and forces. Currently, the enity can be 
                 collided with, but it won't respond when a simulation runs. We need to add a <b>PhysX Rigid Body</b> 
                 component.<br><br>In <b>Entity Inspector</b> click the <b>Add Component</b> button and select the 
                 PhysX Rigid Body component from the list.<br><br>The entity can now be simulated, but 
-                there's a couple more things we need to do before we test it.<br><br><br>Step 10 of 20</p></html>""", 
+                there's a couple more things we need to do before we test it.</p></html>""", 
                 "m_addComponentButton"))
         self.add_step(TutorialStep("Add an initial linear velocity", """<html><p style="font-size:13px">The <b>PhysX 
                 Rigid Body</b> component has a lot of properties. The most important one, <b>Gravity enabled</b>, is 
                 turned on by default. When simulated, the enity will fall due to gravity. Let's add a small upward 
                 initial velocity to the rigid body so we see an interesting result when we run the simulation.<br><br>
                 In the PhysX Rigid Body component, set the <b>Initial linear velocity</b> property's <b>Z</b> value to 
-                <strong><code style="font-size:14px;color:#E44C9A">10</code></strong>.<br><br><br>Step 11 of 
-                20</p></html>""", "InspectorMainWindow"))
+                <strong><code style="font-size:14px;color:#E44C9A">10</code></strong>.</p></html>""", "InspectorMainWindow"))
         self.add_step(TutorialStep("Add an initial angular velocity", """<html><p style="font-size:13px">We can also 
                 spin the dice entity. Let's add a small inital angular velocity to the rigid body as well.<br><br>In the
                  <b>PhysX Rigid Body</b> component, set the <b>Initial angular 
                 velocity</b> property's <b>Y</b> value to 
                 <strong><code style="font-size:14px;color:#E44C9A">15</code></strong>.<br><br>With these two properties 
-                set, the entity will pop straight up and spin when the entity is activated.<br><br><br>Step 12 of 
-                20</p></html>""", "InspectorMainWindow"))
+                set, the entity will pop straight up and spin when the entity is activated.</p></html>""", "InspectorMainWindow"))
         self.add_step(TutorialStep("Exit Focus Mode", """<html><p style="font-size:13px">We're done editing the prefab 
                 instance, so let's exit Focus Mode.<br><br>In <b>Entity Outliner</b> double click the dice prefab 
-                instance to close it.<br><br><br>Step 13 of 20</p></html>""", "EntityOutlinerWidgetUI"))
+                instance to close it.</p></html>""", "EntityOutlinerWidgetUI"))
         self.add_step(TutorialStep("Save the prefab", """<html><p style="font-size:13px">In <b>Entity Outliner</b>, 
                 note the <b>*</b> asterisk next to the dice prefab file name on the left. This tells us the prefab 
                 instance has been edited and there are unsaved changes. Let's save the prefab.<br><br>In Entity 
                 Outliner, right-click the dice prefab instance and choose <b>Save Prefab to file</b>.<br><br>Saving the 
                 prefab overwrites the prefab file on disk. Any new instances of the prefab will contain the <b>PhysX 
-                Collider</b> and <b>PhysX Rigid Body</b> components we added in the previous setps.<br><br><br>Step 14 
-                of 20</p></html>""", "EntityOutlinerWidgetUI"))
+                Collider</b> and <b>PhysX Rigid Body</b> components we added in the previous setps.</p></html>""", "EntityOutlinerWidgetUI"))
         self.add_step(TutorialStep("Add a ground plane collider", """<html><p style="font-size:13px">We need to add a 
                 collider to the ground plane so that the dice prefab instance has a surface to collide against in the 
                 simulation.<br><br>In <b>Entity Outliner</b>, right-click and select <b>Create Entity</b> from the 
-                context menu.<br><br><br>Step 15 of 20</p></html>""", "EntityOutlinerWidgetUI"))
+                context menu.</p></html>""", "EntityOutlinerWidgetUI"))
         self.add_step(TutorialStep("Add a PhysX Shape Collider", """<html><p style="font-size:13px">With the 
                 new enity selected, we'll add a <b>PhysX Shape Collider</b> componnet to create a collision surface for 
                 the ground plane.<br><br>In <b>Entity Inspector</b> click the <b>Add Component</b> button and select the
-                PhysX Shape Collider component from the list.<br><br><br>Step 16 of 20</p></html>""", 
+                PhysX Shape Collider component from the list.</p></html>""", 
                 "m_addComponentButton"))
         self.add_step(TutorialStep("Add a Shape for the ground collider", """<html><p style="font-size:13px">In the 
                 <b>PhysX Shape Collider</b> component, there is a warning about a missing component service. The shape 
                 collider requires a shape component to define the collider. Let's add a shape  
                 component.<br><br>Click the <b>Add Required Component</b> button and select <b>Quad Shape</b> from the 
-                shape component list.<br><br><br>Step 17 of 20</p></html>""", "InspectorMainWindow"))
+                shape component list.</p></html>""", "InspectorMainWindow"))
         self.add_step(TutorialStep("Set the ground collider size", """<html><p style="font-size:13px">The <b>Quad 
                 Shape</b> component is a flat plane with a default size of one meter by one meter. We need to make it 
                 much larger to ensure the dice prefab instance collides with it.<br><br>In the Quad Shape component, set
                  both the <b>Width</b> and <b>Height</b> properties to 
                  <strong><code style="font-size:14px;color:#E44C9A">512</code></strong> so that the collision plane 
-                matches the size of the gorund plane.<br><br><br>Step 18 of 20</p></html>""", "InspectorMainWindow"))
+                matches the size of the gorund plane.</p></html>""", "InspectorMainWindow"))
         self.add_step(TutorialStep("Position the ground collider", """<html><p style="font-size:13px">The ground 
                 collider we just created is not aligned with the ground mesh. Let's move the collider so that 
                 it aligns better with the ground plane.<br><br>With the ground collider entity selected, in the 
                 viewpoort, use the <b>Z</b> handle of the move tool to move the ground collider just enough for 
-                the quad shape to disappear below the ground plane.<br><br><br>Step 19 of 20</p></html>""", 
+                the quad shape to disappear below the ground plane.</p></html>""", 
                 "renderOverlay"))
         self.add_step(TutorialStep("Run the simulation", """<html><p style="font-size:13px">We can now run the 
                 simualtion and view the results. Press <b>CTRL+G</b> to enter game mode and see the dice prefab instance
                  fly in the air an spin, then fall and collide with the ground plane. Press <b>ESC</b> to exit.
-                <br><br><br>Step 20 of 20</p></html>"""))
+                </p></html>"""))
 
     def on_tutorial_start(self):
         print("Starting PhysX Rigid Body tutorial.")

--- a/Editor/Scripts/tutorial.py
+++ b/Editor/Scripts/tutorial.py
@@ -42,7 +42,6 @@ class TutorialStep:
     def get_content(self):
         return self.content
 
-
     def get_highlight_pattern(self):
         return self.highlight_pattern
 
@@ -109,6 +108,5 @@ class Tutorial:
 
         return None
 
-    #list of all steps in the tutorial
     def get_steps(self):
         return self.steps

--- a/Editor/Scripts/tutorial.py
+++ b/Editor/Scripts/tutorial.py
@@ -11,7 +11,7 @@ import os
 
 # Class that describes a step in the tutorial
 class TutorialStep:
-    def __init__(self, title, content, highlight_pattern=None):
+    def __init__(self, title, content, highlight_pattern=None, highlight_parent=None, highlight_index=None):
         self.title = title
         self.content = content
 
@@ -20,6 +20,8 @@ class TutorialStep:
         # This pattern will be passed to `editor_python_test_tools.pyside_utils`
         # to find the widget/item. See its documentation for supported patterns
         self.highlight_pattern = highlight_pattern
+        self.highlight_parent = highlight_parent
+        self.highlight_index = highlight_index
 
         self.prev_step = None
         self.next_step = None
@@ -44,6 +46,12 @@ class TutorialStep:
 
     def get_highlight_pattern(self):
         return self.highlight_pattern
+
+    def get_highlight_parent(self):
+        return self.highlight_parent
+
+    def get_highlight_index(self):
+        return self.highlight_index
 
 # Top-level entry point for describing a tutorial which is made up of a series of steps
 class Tutorial:
@@ -73,7 +81,9 @@ class Tutorial:
             title = step["title"]
             content = step["content"]
             highlight_pattern = step.get("highlight_pattern", None)
-            new_step = TutorialStep(title, content, highlight_pattern)
+            highlight_parent = step.get("highlight_parent", None)
+            highlight_index = step.get("highlight_index", None)
+            new_step = TutorialStep(title, content, highlight_pattern, highlight_parent, highlight_index)
             new_tutorial.add_step(new_step)
 
         return new_tutorial

--- a/Editor/Scripts/tutorial.py
+++ b/Editor/Scripts/tutorial.py
@@ -42,6 +42,7 @@ class TutorialStep:
     def get_content(self):
         return self.content
 
+
     def get_highlight_pattern(self):
         return self.highlight_pattern
 
@@ -108,5 +109,6 @@ class Tutorial:
 
         return None
 
+    #list of all steps in the tutorial
     def get_steps(self):
         return self.steps


### PR DESCRIPTION
Added a tutorial and some functionality that demonstrates finding unnamed Qt objects to highlight by named parent or selecting with an index for scenarios where there are multiple unnamed children of the same Qt object type. Work in progress, looking for feedback. Ultimately we might need a method that uses key-value pairs of Qt object types and indices to create a sort of absolute path for scenarios where a named parent is a couple levels or more up the tree, and the hierarchy contains branches of unnamed Qt objects that are the same type.