### PR TITLE
Highlighting Qt UI Elements

### DIFF
--- a/Editor/Scripts/finding_ui_objects.py
+++ b/Editor/Scripts/finding_ui_objects.py
@@ -1,0 +1,51 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+import sys
+import azlmbr
+
+from PySide2 import QtWidgets
+import editor_python_test_tools.pyside_utils as pyside_utils
+
+from tutorial import Tutorial, TutorialStep
+
+class FindingUIObjectsTutorial(Tutorial):
+    def __init__(self):
+        super(FindingUIObjectsTutorial, self).__init__()
+
+        self.title = "Highlighting UI Objects"
+
+        self.add_step(TutorialStep("Highlighting UI Objects", 
+                """<html><p style="font-size:13px">Greetings!<br><br>This tutorial demonstrates methods to find UI 
+                objects to highlight in tutorial steps. You can use the <b>Object Tree</b> tool to find named UI 
+                objects or a named parent of a UI object. Then, use one of methods in this tutorial to specify the 
+                widget to highlight in a <strong><code style="font-size:14px;color:#E44C9A">TutorialStep</code></strong>
+                .<br><br>The available methods are:<ul><li><b>Highlight by name</b> - Specify the name of the 
+                UI object to highlight.</li><li><b>Highlight by parent</b> - Specify a named parent and a pattern for 
+                the UI object. The UI object is the first child of the parent that matches the specified pattern.</li>
+                <li><b>Highlight from hierarchy with index</b> - Specify an index to select a specific child UI object 
+                when the parent has multiple children that have the same pattern.</li></ul></p></html>"""))
+        self.add_step(TutorialStep("Highlight by name", """<html><p style="font-size:13px">This step highlights the 
+                <b>Entity Outliner</b>, finding it by its name, <strong><code style="font-size:14px;color:#E44C9A">
+                "EntityOutlinerWidgetUI"</code></strong>.</p></html>""", "EntityOutlinerWidgetUI"))
+        self.add_step(TutorialStep("Highlight from parent", """<html><p style="font-size:13px">This step highlights 
+                the <b>Console Variables</b> tool button in the lower-left corner of the Editor. The Console Variables 
+                tool button has a name, but is found through its parent in this example. It is the first QToolButton 
+                child of a QWidget named <strong><code style="font-size:14px;color:#E44C9A">container2</code></strong>.
+                </p></html>""", QtWidgets.QToolButton, "container2"))
+        self.add_step(TutorialStep("Highlight from hierarchy with index", """<html><p style="font-size:13px">This step 
+                highlights the <b>Play</b> tool button in the upper-right corner of the Editor. The Play tool button is 
+                unnamed, and it is the third QToolButton child of a QToolBar named 
+                <strong><code style="font-size:14px;color:#E44C9A">PlayConsole</code></strong>. Supplying 
+                <strong><code style="font-size:14px;color:#E44C9A">2</code></strong> for the index value selects the 
+                third child QToolButton.</p></html>""", QtWidgets.QToolButton, "PlayConsole", 2))
+
+    def on_tutorial_start(self):
+        print("Starting Widget By Hierarchy tutorial.")
+
+    def on_tutorial_end(self):
+        print("Widget By Hierarchy tutorial complete!")

--- a/Editor/Scripts/tutorial.py
+++ b/Editor/Scripts/tutorial.py
@@ -11,7 +11,7 @@ import os
 
 # Class that describes a step in the tutorial
 class TutorialStep:
-    def __init__(self, title, content, highlight_pattern=None):
+    def __init__(self, title, content, highlight_pattern=None, highlight_parent=None, highlight_index=None):
         self.title = title
         self.content = content
 
@@ -20,6 +20,8 @@ class TutorialStep:
         # This pattern will be passed to `editor_python_test_tools.pyside_utils`
         # to find the widget/item. See its documentation for supported patterns
         self.highlight_pattern = highlight_pattern
+        self.highlight_parent = highlight_parent
+        self.highlight_index = highlight_index
 
         self.prev_step = None
         self.next_step = None
@@ -44,6 +46,12 @@ class TutorialStep:
 
     def get_highlight_pattern(self):
         return self.highlight_pattern
+
+    def get_highlight_parent(self):
+        return self.highlight_parent
+
+    def get_highlight_index(self):
+        return self.highlight_index
 
 # Top-level entry point for describing a tutorial which is made up of a series of steps
 class Tutorial:
@@ -73,7 +81,9 @@ class Tutorial:
             title = step["title"]
             content = step["content"]
             highlight_pattern = step.get("highlight_pattern", None)
-            new_step = TutorialStep(title, content, highlight_pattern)
+            highlight_parent = step.get("highlight_parent", None)
+            highlight_index = step.get("highlight_index", None)
+            new_step = TutorialStep(title, content, highlight_pattern, highlight_parent, highlight_index)
             new_tutorial.add_step(new_step)
 
         return new_tutorial


### PR DESCRIPTION
Added a tutorial and some functionality that demonstrates finding unnamed Qt objects to highlight by named parent or selecting with an index for scenarios where there are multiple unnamed children of the same Qt object type. Work in progress, looking for feedback. Ultimately we might need a method that uses key-value pairs of Qt object types and indices to create a sort of absolute path for scenarios where a named parent is a couple levels or more up the tree, and the hierarchy contains branches of unnamed Qt objects that are the same type.

Signed-off-by: Mike Cronin <58789750+micronAMZN@users.noreply.github.com>